### PR TITLE
feat: 운동 세트, 횟수, 무게 추가 구현

### DIFF
--- a/src/main/java/com/mirae/DailyBoost/exercise/domain/business/ExerciseBusiness.java
+++ b/src/main/java/com/mirae/DailyBoost/exercise/domain/business/ExerciseBusiness.java
@@ -138,7 +138,10 @@ public class ExerciseBusiness {
               "description": "운동 설명",
               "youtubeLink": "유튜브 링크",
               "level": "BEGINNER", "INTERMEDIATE", "ADVANCED", 이 세개중에서 사용자 선택으로
-              "part": "운동 부위"
+              "part": "운동 부위",
+              "sets": "세트 수",
+              "reps": "횟수",
+              "weight": "무게"
             }
             
             """)
@@ -176,7 +179,10 @@ public class ExerciseBusiness {
               "description": "운동 설명",
               "youtubeLink": "유튜브 링크", 볼 수 있는 영상 링크로 보내주세요.
               "level": "BEGINNER", "INTERMEDIATE", "ADVANCED", 난이도는 초보, 중급 정도로 추천
-              "part" : 운동 부위는 아무거나 랜덤으로 추천
+              "part" : 운동 부위는 아무거나 랜덤으로 추천,
+              "sets": "세트 수",
+              "reps": "횟수",
+              "weight": "무게"
             }
             
             """)

--- a/src/main/java/com/mirae/DailyBoost/exercise/domain/controller/ExerciseController.java
+++ b/src/main/java/com/mirae/DailyBoost/exercise/domain/controller/ExerciseController.java
@@ -58,7 +58,7 @@ public class ExerciseController {
         return Api.OK(exerciseBusiness.recommendExercise(userDTO, exerciseRequest));
     }
 
-    @GetMapping("{exerciseId}") //api/exercise/{exerciseId}
+    @GetMapping("/{exerciseId:[0-9]+}") //api/exercise/{exerciseId}
     public Api<ExerciseResponse> getExercise(@LoginUser UserDTO userDTO, @PathVariable Long exerciseId) {
         return Api.OK(exerciseBusiness.getExercise(userDTO, exerciseId));
     }

--- a/src/main/java/com/mirae/DailyBoost/exercise/domain/controller/model/response/ExerciseRecommendation.java
+++ b/src/main/java/com/mirae/DailyBoost/exercise/domain/controller/model/response/ExerciseRecommendation.java
@@ -2,6 +2,7 @@ package com.mirae.DailyBoost.exercise.domain.controller.model.response;
 
 import com.mirae.DailyBoost.exercise.domain.repository.enums.ExercisePart;
 import com.mirae.DailyBoost.exercise.domain.repository.enums.Level;
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,4 +18,7 @@ public class ExerciseRecommendation {
   String youtubeLink;
   Level level;
   ExercisePart part;
+  Integer sets;
+  Integer reps;
+  Double weight;
 }

--- a/src/main/java/com/mirae/DailyBoost/exercise/domain/repository/Exercise.java
+++ b/src/main/java/com/mirae/DailyBoost/exercise/domain/repository/Exercise.java
@@ -40,6 +40,18 @@ public class Exercise {
   @Column(nullable = false)
   private String description;
 
+  @Builder.Default
+  @Column(nullable = false)
+  private Integer sets = 0;
+
+  @Builder.Default
+  @Column(nullable = false)
+  private Integer reps = 0;
+
+  @Builder.Default
+  @Column(nullable = false)
+  private Double weight = 0.0;
+
   @Column(name = "registered_at", nullable = true)
   private LocalDate registeredAt;
 


### PR DESCRIPTION
기존 운동 추천 시스템에는 세트수, 횟수, 무게 필드가 없어서 초보자가 운동만 추천받는 기능이었음.
변경 후에는 운동 초보자에 맞춰 세트수, 횟수, 무게 까지 추가하여 초보자 맞춤형 으로 운동을 추천받게 되었음.